### PR TITLE
fix esp_sleep API name change for TimerWakeUp

### DIFF
--- a/TimerWakeUp/TimerWakeUp.ino
+++ b/TimerWakeUp/TimerWakeUp.ino
@@ -29,9 +29,9 @@ Method to print the reason by which ESP32
 has been awaken from sleep
 */
 void print_wakeup_reason(){
-  esp_deep_sleep_wakeup_cause_t wakeup_reason;
+  esp_sleep_wakeup_cause_t wakeup_reason;
 
-  wakeup_reason = esp_deep_sleep_get_wakeup_cause();
+  wakeup_reason = esp_sleep_get_wakeup_cause();
 
   switch(wakeup_reason)
   {
@@ -59,7 +59,7 @@ void setup(){
   First we configure the wake up source
   We set our ESP32 to wake up every 5 seconds
   */
-  esp_deep_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
+  esp_sleep_enable_timer_wakeup(TIME_TO_SLEEP * uS_TO_S_FACTOR);
   Serial.println("Setup ESP32 to sleep for every " + String(TIME_TO_SLEEP) +
   " Seconds");
 
@@ -84,6 +84,7 @@ void setup(){
   reset occurs.
   */
   Serial.println("Going to sleep now");
+  Serial.flush();
   esp_deep_sleep_start();
   Serial.println("This will never be printed");
 }


### PR DESCRIPTION
This is the same fix as https://github.com/SensorsIot/ESP32-Deep-Sleep/pull/2.